### PR TITLE
some fixes to the requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ attrs==22.1.0
 backcall==0.2.0
 beautifulsoup4==4.11.1
 bleach==5.0.1
-certifi @ file:///croot/certifi_1665076670883/work/certifi
+#certifi @ file:///croot/certifi_1665076670883/work/certifi
+certifi
 cffi==1.15.1
 contourpy==1.0.6
 cycler==0.11.0
@@ -47,7 +48,8 @@ nest-asyncio==1.5.6
 notebook==6.5.2
 notebook_shim==0.2.2
 numpy==1.23.4
-packaging==21.3
+#packaging==21.3
+packaging
 pandas==1.5.1
 pandocfilters==1.5.0
 parso==0.8.3


### PR DESCRIPTION
 so that

pip install -r requirements.txt

_does_ work under a conda environment.

I would _way_ prefer a python venv to be enough.
Conda is overkill; conda is slow; conda is the dumbest package manager I have ever dealt with in my life... :-(
conda doesn't even have a system package under Debian !
I cannot do 'sudo apt install conda'...
The Python community should walk away from conda.
